### PR TITLE
(begin to) Add FWHM to velocity.gaussians montecarlo

### DIFF
--- a/misfits/__init__.py
+++ b/misfits/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0'
+__version__ = '1.1'
 
 from .file import readfile
 from .spectrum import Spectrum

--- a/misfits/tools/uncertainty/montecarlo.py
+++ b/misfits/tools/uncertainty/montecarlo.py
@@ -70,7 +70,8 @@ class MonteCarlo (BaseIterator) :
             if 'velocity.gaussians' in str(self.feature):
                 self.fwhm = True
                 self.sigmas.append(res[3])
-
+            else:
+                self.fwhm = False
         print(''.ljust(l), file=sys.stderr, end='\r')
 
         self.feature.set_parameters(**self.params)

--- a/misfits/tools/velocity/gaussians.py
+++ b/misfits/tools/velocity/gaussians.py
@@ -68,7 +68,7 @@ class Gaussians (BaseToolGaussians) :
         self.continuum = []
         self.amplitudes = []
         self.x0s, std_x0s = [], []
-        self.stddevs = []
+        self.stddevs, std_stddevs = [], []
 
         chi2s = []
 
@@ -84,9 +84,10 @@ class Gaussians (BaseToolGaussians) :
                 getattr(self, k).append(v)
             std_x0s.append(std['x0s'])
             chi2s.append(chi2)
+            std_stddevs.append(std['stddevs'])
 
         self.continuum = list(map(tuple, self.continuum))
         self.limits = limits
         self.references = references
 
-        return deepcopy(self.x0s), std_x0s, chi2s
+        return deepcopy(self.x0s), std_x0s, chi2s, deepcopy(self.stddevs), std_stddevs


### PR DESCRIPTION
This PR adds an additional feature for velocity.gaussians. Instead of just the minimum/maximum, it also now returns the FWHM in angstrom. The details are below but so far it has limited interface with other features of misfits such as calculating the velocity values given a reference line or reporting in the JSON or showing up in the GUI. However, the output works and it can be used to add full support for FWHM down the line.

My own git commit message: 

Adds FWHM calculation to velocity.gaussians using montecarlo for uncertainty. Template can be used to implement this in other gaussian methods. Modifies gaussians.py iterator created by the @BaseToolGaussians decorater call method to return also the deepcopy and uncertainty of the stddevs, which are needed to calculate FWHM for a gaussian. It's worth checking whether this additional return taking the shape of the return from 3 to 5 changes or breaks anything. These additional returns are added to the end and have been verified to work with headless and GUU velocity.gaussians montecarlo.

Currently, the calculation is only done for ASCII mode and not for JSON.